### PR TITLE
Fix citation link regex idempotency

### DIFF
--- a/tests/test_convert_citations_links.py
+++ b/tests/test_convert_citations_links.py
@@ -1,0 +1,15 @@
+import re
+from rag_assistant_simple_redis import EnhancedSimpleRedisRAGAssistant
+
+
+def _count_anchors(text: str) -> int:
+    return len(re.findall(r'<a[^>]+session-citation-link', text))
+
+
+def test_convert_citations_idempotent():
+    assistant = EnhancedSimpleRedisRAGAssistant.__new__(EnhancedSimpleRedisRAGAssistant)
+    raw = "Example [1] more [2]."
+    first = assistant._convert_citations_to_links(raw, [], "m")
+    second = assistant._convert_citations_to_links(first, [], "m")
+    assert first == second
+    assert _count_anchors(second) == 2


### PR DESCRIPTION
## Summary
- make citation link conversion idempotent using negative lookbehind/ahead
- add regression test for repeated conversion

## Testing
- `pytest tests/test_convert_citations_links.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688bf5ecbbe883288e9170de83f821c7