### PR TITLE
feat: skip reprocessing existing citation links

### DIFF
--- a/static/js/session-citation-system.js
+++ b/static/js/session-citation-system.js
@@ -132,11 +132,19 @@
    * Format text with session-wide citations
    * @param {string} text - Raw text with citation markers
    * @param {Array} sources - Array of source objects (will be registered)
-   * @returns {Promise<string>} - Formatted HTML with citation links
+   * @returns {Promise<string>} - Formatted HTML with citation links. If the
+   *   text already contains pre-rendered citation links, it is returned
+   *   unchanged.
    */
   async function formatTextWithCitations(text, sources = []) {
     if (typeof text !== 'string') {
       return String(text || '');
+    }
+
+    // If citation links are already present, skip conversion to avoid
+    // reprocessing server-rendered citation links
+    if (text.includes('session-citation-link')) {
+      return text;
     }
 
     // Register sources first to get session-wide citation IDs


### PR DESCRIPTION
## Summary
- avoid converting citation markers when text already contains `session-citation-link`
- document early return behavior in `formatTextWithCitations`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'rag_assistant_v2')*

------
https://chatgpt.com/codex/tasks/task_e_688bfb2d3d188328a19e3bc7bb3ab1ec